### PR TITLE
Fix crash when deleting a line. Reset selection.

### DIFF
--- a/EditorPlusExtension/SourceEditorCommand.swift
+++ b/EditorPlusExtension/SourceEditorCommand.swift
@@ -10,25 +10,33 @@ import Foundation
 import XcodeKit
 
 class SourceEditorCommand: NSObject, XCSourceEditorCommand {
-    
-    func perform(with invocation: XCSourceEditorCommandInvocation, completionHandler: (NSError?) -> Void ) -> Void {
+
+    public func perform(with invocation: XCSourceEditorCommandInvocation,
+                        completionHandler: @escaping (Error?) -> Swift.Void) {
 
         /// Fail fast if there is no text selected at all or there is no text in the file
-        guard let textRange = invocation.buffer.selections.firstObject as? XCSourceTextRange
-            where invocation.buffer.lines.count > 0 else {
+        guard let textRange = invocation.buffer.selections.firstObject as? XCSourceTextRange,
+                              invocation.buffer.lines.count > 0 else {
                 /// Usually we may want to pass a concrete error into handler block.
                 /// But in this case, it's fine to let it failed silencely.
                 completionHandler(nil)
                 return
         }
 
+        /// Properly handle line selections
+        let lineSelection = textRange.start.column == 0
+          && textRange.end.column == 0
+          && textRange.start.line != textRange.end.line
+        let upperBound = lineSelection ? textRange.end.line : textRange.end.line + 1
+
         /// Build target range(Range<Int>) based on given text range(XCSourceTextRange)
-        let targetRange = Range(uncheckedBounds: (lower: textRange.start.line, upper: min(textRange.end.line + 1, invocation.buffer.lines.count)))
+        let targetRange = Range(uncheckedBounds: (lower: textRange.start.line, upper: min(upperBound, invocation.buffer.lines.count)))
 
         /// Switch all different commands id based which defined in Info.plist
         switch invocation.commandIdentifier {
         case "delete_lines":
             deleteLines(on: targetRange, with: invocation)
+            resetSelection(to: targetRange.lowerBound, with: invocation)
         case "duplicate_lines":
             duplicateLines(on: targetRange, with: invocation)
         default:
@@ -47,7 +55,7 @@ extension SourceEditorCommand {
     ///
     /// - parameter range:      range of lines should be deleted
     /// - parameter invocation: invocation which contains the text buffer invovled
-    private func deleteLines(on range: Range<Int>, with invocation: XCSourceEditorCommandInvocation) {
+    fileprivate func deleteLines(on range: Range<Int>, with invocation: XCSourceEditorCommandInvocation) {
 
         invocation.buffer.lines.removeObjects(at: IndexSet(integersIn: range))
     }
@@ -57,11 +65,23 @@ extension SourceEditorCommand {
     ///
     /// - parameter range:      range of lines should be duplicated
     /// - parameter invocation: invocation which contains the text buffer invovled
-    private func duplicateLines(on range: Range<Int>, with invocation: XCSourceEditorCommandInvocation) {
+    fileprivate func duplicateLines(on range: Range<Int>, with invocation: XCSourceEditorCommandInvocation) {
 
         let indexSet = IndexSet(integersIn: range)
         let selectedLines = invocation.buffer.lines.objects(at: indexSet)
 
         invocation.buffer.lines.insert(selectedLines, at: indexSet)
     }
+  
+    /// The method will reset selection to the beginning of the given line.
+    ///
+    /// - parameter line:       line to reset selection to
+    /// - parameter invocation: invocation which contains the text buffer invovled
+    fileprivate func resetSelection(to line: Int, with invocation: XCSourceEditorCommandInvocation) {
+        invocation.buffer.selections.removeAllObjects()
+        let position = XCSourceTextPosition(line: line, column: 0)
+        let selection = XCSourceTextRange(start: position, end: position)
+        invocation.buffer.selections.add(selection)
+    }
+
 }


### PR DESCRIPTION
- Fixed crash #3. Some selection configurations lead to empty selection after delete. Resetting selection fixes the crash and feels more natural in general (IMHO).
- Will now correctly delete a line selection (when selected via Shift + Up/Down in the beginning of a line).
- Updated to Swift 3 syntax.